### PR TITLE
Change bottom margin to 0

### DIFF
--- a/components/GridPage.module.css
+++ b/components/GridPage.module.css
@@ -100,7 +100,7 @@
 }
 
 .card h3 {
-  margin: 0 0 1rem 0;
+  margin: 0 0 0 0;
   font-size: 1.5rem;
 }
 


### PR DESCRIPTION
The cards had a bottom margin that prevented the text from being vertically-aligned to center. Maybe this was done as a stylistic choice, but I think center is more visually appealing 😌

This PR sets the margin to 0.

|Before|After|
|---|---|
|![center-before](https://user-images.githubusercontent.com/32581742/114316915-487b2280-9acb-11eb-9467-3c2a1fc42c7e.png)|![center-after](https://user-images.githubusercontent.com/32581742/114316914-47e28c00-9acb-11eb-8c4f-f07a8a67bc0f.png)|